### PR TITLE
ci: enforce semantic PRs via GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL
+name: codeql
 
 on:
   - pull_request

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,64 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Install npm packages
+        run: yarn --frozen-lockfile
+      - name: Check lint
+        run: yarn lint
+
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Install npm packages
+        run: yarn --frozen-lockfile
+      - name: Check formatting
+        run: yarn fmt:check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Install npm packages
+        run: yarn --frozen-lockfile
+      - name: Check types
+        run: yarn typecheck
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.6.23
+        with:
+          args: -color

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: release
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        name: create release
+        with:
+          release-type: node
+#          extra-files: |
+#            README.md

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,0 +1,18 @@
+name: lint
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  semantic-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-name: Main workflow
+name: build
 
 on:
   - pull_request
@@ -38,15 +38,6 @@ jobs:
 
       - name: Install npm packages
         run: yarn --frozen-lockfile
-
-      - name: Check formatting
-        run: yarn fmt:check
-
-      - name: Check lint
-        run: yarn lint
-
-      - name: Check type
-        run: yarn typecheck
 
       - name: Ensure out directories are up-to-date
         if: runner.os == 'Linux'

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-nodejs 16.18.0
+nodejs 16.19.1
+yarn 1.22.19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [1.1.0] - 2020-12-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asdf-vm/actions",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "asdf github actions",
   "repository": "https://github.com/asdf-vm/actions",
   "author": "Victor Borja <vborja@apache.org>",


### PR DESCRIPTION
- [x] add `release-please-action` with `node` configuration
- [x] extract linting workflows into their own parallel jobs to tighten feedback loop
- [x] update `package.json` version number to align with existing GitHub release
- [x] update `nodejs` in `.tool-versions`
- [x] track `yarn` version in `.tool-versions`
- [x] add `semantic-pr` workflow